### PR TITLE
Refactor Test Targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
         .library(
             name: "CoronaErrors",
             targets: ["CoronaErrors"]),
+        .library(
+            name: "CoronaErrorsTestHooks",
+            targets: ["CoronaErrorsTestHooks"])
     ],
     dependencies: [
         
@@ -18,8 +21,11 @@ let package = Package(
         .target(
             name: "CoronaErrors",
             dependencies: []),
+        .target(
+            name: "CoronaErrorsTestHooks",
+            dependencies: ["CoronaErrors"]),
         .testTarget(
             name: "CoronaErrorsTests",
-            dependencies: ["CoronaErrors"]),
+            dependencies: ["CoronaErrors", "CoronaErrorsTestHooks"]),
     ]
 )

--- a/Sources/CoronaErrorsMain/main.swift
+++ b/Sources/CoronaErrorsMain/main.swift
@@ -1,0 +1,1 @@
+print("cooper")

--- a/Sources/CoronaErrorsTestHooks/Exception+XCTest.swift
+++ b/Sources/CoronaErrorsTestHooks/Exception+XCTest.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoronaErrors
 import XCTest
 
 ///Asserts that a given closure throws a specific type of exception. Fails the test
@@ -22,3 +23,4 @@ public func XCTAssertThrowsException<T>(type:T.Type, closure:() throws -> Void) 
         XCTFail("Expected \(T.self) to be thrown. Actual: \(error)")
     }
 }
+


### PR DESCRIPTION
Refactored targets to remove dependency on XCTest in runnable executables (which crashes the program).